### PR TITLE
Improved ELO graph

### DIFF
--- a/app/components/elo-history-charts.tsx
+++ b/app/components/elo-history-charts.tsx
@@ -14,34 +14,140 @@ import {
   type TeamPlayerELOLog,
 } from '@prisma/client';
 import { BASE_ELO } from '~/utils/constants';
+import { useWindowSize } from '~/utils/hooks/use-window-size';
+import { useState } from 'react';
+import { ToggleSwitch } from '~/components/toggle-switch';
+
+const formatSimpleDate = (date: string) => {
+  return new Date(date).toLocaleString('no-NO', {
+    month: '2-digit',
+    day: '2-digit',
+  });
+};
+
+const formatDateWithTime = (date: string) => {
+  return new Date(date).toLocaleString('no-NO', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const formatDateOnly = (date: string) => {
+  return new Date(date).toLocaleString('no-NO', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+};
+
+const aggregateByDay = (data: any[]) => {
+  if (data.length === 0) return [];
+
+  // First, group by day as before
+  const groupedByDay = data.reduce((acc, item) => {
+    const date = new Date(item.date);
+    const dayKey = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+      .toISOString()
+      .split('T')[0];
+
+    if (!acc[dayKey]) {
+      acc[dayKey] = { date: dayKey, elos: [] };
+    }
+    acc[dayKey].elos.push(item.elo);
+    return acc;
+  }, {});
+
+  // Find start date and use today as end date
+  const dates = Object.keys(groupedByDay).sort();
+  const startDate = new Date(dates[0]);
+  const endDate = new Date(); // Use today's date
+  endDate.setHours(23, 59, 59, 999); // Set to end of today
+
+  // Fill in all days from start until today
+  const filledData = [];
+  let currentDate = new Date(startDate);
+  let lastKnownElo = BASE_ELO;
+
+  while (currentDate <= endDate) {
+    const dateKey = currentDate.toISOString().split('T')[0];
+    const dayData = groupedByDay[dateKey];
+
+    if (dayData) {
+      // Calculate average ELO for days with matches
+      const avgElo = Math.round(
+        dayData.elos.reduce((sum: number, elo: number) => sum + elo, 0) /
+          dayData.elos.length
+      );
+      lastKnownElo = avgElo;
+      filledData.push({
+        date: dateKey,
+        elo: avgElo,
+        hasMatches: true,
+      });
+    } else {
+      // Use last known ELO for days without matches
+      filledData.push({
+        date: dateKey,
+        elo: lastKnownElo,
+        hasMatches: false,
+      });
+    }
+
+    // Move to next day
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+
+  return filledData;
+};
 
 interface Props {
   data: ELOLog[] | TeamELOLog[] | TeamPlayerELOLog[];
 }
 
+const CustomTooltip = ({ active, payload, showDailyView }: any) => {
+  if (active && payload && payload.length) {
+    const date = payload[0].payload.date;
+    const formattedDate = showDailyView
+      ? formatDateOnly(date)
+      : formatDateWithTime(date);
+
+    return (
+      <div className="rounded-lg border border-gray-700 bg-gray-800/95 p-2 text-sm shadow-lg sm:p-3 sm:text-base">
+        <p className="text-xs text-gray-200 sm:text-sm">{formattedDate}</p>
+        <p className="text-base font-semibold text-white sm:text-lg">
+          ELO: {payload[0].value}
+        </p>
+      </div>
+    );
+  }
+  return null;
+};
+
 export const EloHistoryChart = ({ data }: Props) => {
+  const [showDailyView, setShowDailyView] = useState(false);
+  const { width } = useWindowSize();
+  const isMobile = width ? width < 640 : false;
+
+  const processedData = showDailyView ? aggregateByDay(data) : data;
+
   const massagedData =
-    data.length > 0
+    processedData.length > 0
       ? [
           {
             date: new Date(
-              new Date(data[0].date).getTime() - 5 * 60000
+              new Date(processedData[0].date).getTime() - 5 * 60000
             ).toISOString(),
             elo: BASE_ELO,
           },
-          ...data.map((dataPoint) => ({
-            date: dataPoint.date,
-            elo: dataPoint.elo,
-          })),
+          ...processedData,
         ].map((item) => ({
-          date: new Date(item.date).toLocaleString('no-NO', {
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-            hour: '2-digit',
-            minute: '2-digit',
-          }),
+          date: item.date,
+          displayDate: formatSimpleDate(item.date.toString()),
           elo: item.elo,
+          hasMatches: 'hasMatches' in item ? item.hasMatches : false,
         }))
       : [];
 
@@ -50,21 +156,64 @@ export const EloHistoryChart = ({ data }: Props) => {
 
   const yAxisDomain = [minElo - 50, maxElo + 50];
 
+  const axisColor = '#94a3b8';
+
   return (
-    <ResponsiveContainer width="100%" height={300}>
-      <LineChart data={massagedData}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="date" />
-        <YAxis domain={yAxisDomain} />
-        <Tooltip />
-        <Legend />
-        <Line
-          type="monotone"
-          dataKey="elo"
-          stroke="#8884d8"
-          activeDot={{ r: 8 }}
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <ToggleSwitch
+          checked={showDailyView}
+          onChange={setShowDailyView}
+          label="Vis ELO-endring per dag"
         />
-      </LineChart>
-    </ResponsiveContainer>
+      </div>
+      <ResponsiveContainer width="100%" height={isMobile ? 200 : 300}>
+        <LineChart data={massagedData}>
+          <defs>
+            <linearGradient id="eloColor" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="rgba(255, 255, 255, 0.1)"
+            vertical={false}
+          />
+          <XAxis
+            dataKey="displayDate"
+            tick={{ fill: axisColor, fontSize: isMobile ? 10 : 12 }}
+            tickLine={{ stroke: axisColor }}
+            stroke={axisColor}
+            angle={isMobile ? -45 : 0}
+            textAnchor={isMobile ? 'end' : 'middle'}
+            height={isMobile ? 60 : 30}
+          />
+          <YAxis
+            domain={yAxisDomain}
+            tick={{ fill: axisColor, fontSize: isMobile ? 10 : 12 }}
+            tickLine={{ stroke: axisColor }}
+            stroke={axisColor}
+            width={isMobile ? 30 : 40}
+          />
+          <Tooltip
+            content={(props) => (
+              <CustomTooltip {...props} showDailyView={showDailyView} />
+            )}
+            wrapperStyle={{ zIndex: 1000 }}
+          />
+          <Legend wrapperStyle={{ color: axisColor }} />
+          <Line
+            type="monotone"
+            dataKey="elo"
+            stroke="#3b82f6"
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 6, fill: '#3b82f6', stroke: '#fff' }}
+            fill="url(#eloColor)"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
   );
 };

--- a/app/components/toggle-switch.tsx
+++ b/app/components/toggle-switch.tsx
@@ -1,0 +1,31 @@
+interface ToggleSwitchProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label: string;
+}
+
+export function ToggleSwitch({ checked, onChange, label }: ToggleSwitchProps) {
+  return (
+    <label className="flex cursor-pointer items-center gap-2">
+      <div className="relative">
+        <input
+          type="checkbox"
+          className="sr-only"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        <div
+          className={`h-6 w-10 rounded-full shadow-inner ${
+            checked ? 'bg-blue-500' : 'bg-gray-400'
+          }`}
+        />
+        <div
+          className={`absolute left-1 top-1 h-4 w-4 transform rounded-full bg-white transition-transform ${
+            checked ? 'translate-x-4' : 'translate-x-0'
+          }`}
+        />
+      </div>
+      <span className="text-sm text-gray-700 dark:text-gray-300">{label}</span>
+    </label>
+  );
+}

--- a/app/routes/compare-players.$player1Id.$player2Id.tsx
+++ b/app/routes/compare-players.$player1Id.$player2Id.tsx
@@ -112,45 +112,48 @@ export default function Index() {
       </div>
 
       {player1 && player2 && (
-        <>
-          <div className="container flex flex-col justify-center">
-            <h2 className="mb-2 text-xl font-bold dark:text-green-200">
-              Sammenligning {player1.name} vs {player2.name}
-            </h2>
-            <table
-              className="mb-2 table-auto rounded-lg bg-blue-100
-             p-4 text-lg text-black shadow-lg dark:bg-gray-700 dark:text-white"
-            >
-              <thead>
-                <tr className="text-md">
-                  <th className="w-1/5 py-2"># kamper</th>
-                  <th className="w-1/5 py-2"># seiere</th>
-                  <th className="w-1/5 py-2"># tap</th>
-                  <th className="w-2/5 py-2">% overlegenhet</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr className="text-md">
-                  <td className="border py-2">
-                    {player1WinStats?.numberOfMatches}
-                  </td>
-                  <td className="border py-2">
-                    {player1WinStats?.numberOfMatchesWonByPlayer}
-                  </td>
-                  <td className="border py-2">
-                    {player1WinStats?.numberOfMatchesLostByPlayer}
-                  </td>
-                  <td className="border py-2">
-                    {player1WinStats?.winPercentage
-                      ? player1WinStats.winPercentage.toFixed(2)
-                      : 0}
-                    %
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+        <div className="container flex flex-col justify-center">
+          <h2 className="mb-4 text-2xl font-bold text-gray-900 dark:text-white">
+            Sammenligning {player1.name} vs {player2.name}
+          </h2>
+          <div className="grid grid-cols-4 gap-4 rounded-lg bg-white p-6 pr-8 shadow-lg dark:bg-gray-800">
+            <div className="text-center">
+              <div className="text-3xl font-bold text-blue-600 dark:text-blue-400">
+                {player1WinStats?.numberOfMatches}
+              </div>
+              <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                Kamper
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-green-600 dark:text-green-400">
+                {player1WinStats?.numberOfMatchesWonByPlayer}
+              </div>
+              <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                Seiere
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-red-600 dark:text-red-400">
+                {player1WinStats?.numberOfMatchesLostByPlayer}
+              </div>
+              <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                Tap
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-blue-600 dark:text-blue-400">
+                {player1WinStats?.winPercentage
+                  ? player1WinStats.winPercentage.toFixed(2)
+                  : 0}
+                %
+              </div>
+              <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                Overlegenhet
+              </div>
+            </div>
           </div>
-        </>
+        </div>
       )}
     </div>
   );

--- a/app/routes/profile.$profileId.tsx
+++ b/app/routes/profile.$profileId.tsx
@@ -232,47 +232,58 @@ export default function Index() {
             </div>
           </ul>
           <div className="flex flex-col justify-center">
-            <h2 className="mb-2 text-xl font-bold dark:text-green-200">
-              Duellspill
+            <h2 className="mb-4 text-2xl font-bold text-gray-900 dark:text-white">
+              Duellspill Statistikk
             </h2>
-            <table
-              className="mb-2 table-auto rounded-lg bg-blue-100
-             p-4 text-lg text-black shadow-lg dark:bg-gray-700 dark:text-white"
-            >
-              <thead>
-                <tr className="text-md">
-                  <th className="w-1/5 py-2"># kamper</th>
-                  <th className="w-1/5 py-2"># seiere</th>
-                  <th className="w-1/5 py-2"># tap</th>
-                  <th className="w-2/5 py-2">% overlegenhet</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr className="text-md">
-                  <td className="border py-2">{numberOfMatches}</td>
-                  <td className="border py-2">{numberOfWins}</td>
-                  <td className="border py-2">{numberOfLosses}</td>
-                  <td className="border py-2">
-                    {`${winPercentage ? winPercentage.toFixed(2) : 0} %`}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+            <div className="grid grid-cols-4 gap-4 rounded-lg bg-white p-6 shadow-lg dark:bg-gray-800">
+              <div className="text-center">
+                <div className="text-3xl font-bold text-blue-600 dark:text-blue-400">
+                  {numberOfMatches}
+                </div>
+                <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  Kamper
+                </div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-green-600 dark:text-green-400">
+                  {numberOfWins}
+                </div>
+                <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  Seiere
+                </div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-red-600 dark:text-red-400">
+                  {numberOfLosses}
+                </div>
+                <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  Tap
+                </div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-blue-600 dark:text-blue-400">
+                  {winPercentage ? winPercentage.toFixed(1) : 0}%
+                </div>
+                <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  Win Rate
+                </div>
+              </div>
+            </div>
           </div>
-          {player.teamPlayerELOLog.length > 0 && (
-            <>
-              <h1 className="my-4 text-xl font-bold">
-                {player.name} sin ELO-historikk i lagspill
-              </h1>
-              <EloHistoryChart data={[...player.teamPlayerELOLog].reverse()} />
-            </>
-          )}
           {player.eloLogs.length > 0 && (
             <>
               <h1 className="my-4 text-xl font-bold">
                 {player.name} sin ELO-historikk i duellspill
               </h1>
               <EloHistoryChart data={[...player.eloLogs].reverse()} />
+            </>
+          )}
+          {player.teamPlayerELOLog.length > 0 && (
+            <>
+              <h1 className="my-4 text-xl font-bold">
+                {player.name} sin ELO-historikk i lagspill
+              </h1>
+              <EloHistoryChart data={[...player.teamPlayerELOLog].reverse()} />
             </>
           )}
         </div>

--- a/app/routes/team-profile.$teamId.tsx
+++ b/app/routes/team-profile.$teamId.tsx
@@ -89,32 +89,43 @@ export default function Index() {
             </li>
           </ul>
           <div className="flex flex-col justify-center">
-            <h2 className="mb-2 text-xl font-bold dark:text-green-200">
-              Lagspill
+            <h2 className="mb-4 text-2xl font-bold text-gray-900 dark:text-white">
+              Lagspill Statistikk
             </h2>
-            <table
-              className="mb-2 table-auto rounded-lg bg-blue-100
-             p-4 text-lg text-black shadow-lg dark:bg-gray-700 dark:text-white"
-            >
-              <thead>
-                <tr className="text-md">
-                  <th className="w-1/5 py-2"># kamper</th>
-                  <th className="w-1/5 py-2"># seiere</th>
-                  <th className="w-1/5 py-2"># tap</th>
-                  <th className="w-2/5 py-2">% overlegenhet</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr className="text-md">
-                  <td className="border py-2">{numberOfMatches}</td>
-                  <td className="border py-2">{numberOfWins}</td>
-                  <td className="border py-2">{numberOfLosses}</td>
-                  <td className="border py-2">
-                    {`${winPercentage ? winPercentage.toFixed(2) : 0} %`}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+            <div className="grid grid-cols-4 gap-4 rounded-lg bg-white p-6 pr-8 shadow-lg dark:bg-gray-800">
+              <div className="text-center">
+                <div className="text-3xl font-bold text-blue-600 dark:text-blue-400">
+                  {numberOfMatches}
+                </div>
+                <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  Kamper
+                </div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-green-600 dark:text-green-400">
+                  {numberOfWins}
+                </div>
+                <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  Seiere
+                </div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-red-600 dark:text-red-400">
+                  {numberOfLosses}
+                </div>
+                <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  Tap
+                </div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold text-blue-600 dark:text-blue-400">
+                  {winPercentage ? winPercentage.toFixed(1) : 0}%
+                </div>
+                <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  Win Rate
+                </div>
+              </div>
+            </div>
           </div>
           {team.TeamELOLog.length > 0 && (
             <>

--- a/app/utils/hooks/use-window-size.ts
+++ b/app/utils/hooks/use-window-size.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+
+interface WindowSize {
+  width: number | undefined;
+  height: number | undefined;
+}
+
+export function useWindowSize() {
+  const [windowSize, setWindowSize] = useState<WindowSize>({
+    width: undefined,
+    height: undefined,
+  });
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowSize;
+}


### PR DESCRIPTION
- Forbedret graf ved å gjøre grafen, tooltipen og aksene tydeligere og mer informative. Også statistikken over er tydeligere med litt farger.
- Også lagt inn modus på grafene slik at man kan se endring i ELO per dag, ikke bare per kamp. Da ser man tydeligere lengre pauser i spillingen og lignende.
- Endringene er lagt inn på Profilsiden, Lagsiden og Sammenlignsiden.

Før:
<img width="871" alt="Screenshot 2025-02-12 at 15 27 50" src="https://github.com/user-attachments/assets/6f02924d-1537-4635-8e8a-bbf998a19ddb" />
Etter:
<img width="870" alt="Screenshot 2025-02-12 at 15 27 22" src="https://github.com/user-attachments/assets/38d25fa5-3608-402b-a161-96b22eaeaa91" />
<img width="874" alt="Screenshot 2025-02-12 at 15 27 34" src="https://github.com/user-attachments/assets/508e0672-fbcd-4f39-ab53-0f9d4d9e5c84" />
<img width="407" alt="Screenshot 2025-02-13 at 10 03 56" src="https://github.com/user-attachments/assets/b60f592f-525e-4a29-80a1-3f5ff13af1ec" />
<img width="868" alt="Screenshot 2025-02-12 at 15 30 23" src="https://github.com/user-attachments/assets/56dfe95d-46e7-4e23-961a-d2d5ae11be52" />
<img width="870" alt="Screenshot 2025-02-12 at 15 29 32" src="https://github.com/user-attachments/assets/a56207e9-f84e-422e-b71a-522deaa35c98" />
<img width="861" alt="Screenshot 2025-02-12 at 15 28 09" src="https://github.com/user-attachments/assets/e40ecd30-d50b-4031-a19b-09352dd8ab8b" />
<img width="866" alt="Screenshot 2025-02-12 at 15 29 43" src="https://github.com/user-attachments/assets/43a3d67a-3f0b-4462-9373-da805d6fe032" />
